### PR TITLE
modify_proxy: Fix response code check + message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-toxiproxy/compare/0.1.3...HEAD
 
+### Changed
+
+- Fixed modify_proxy action: Does not error on a successful call and returns proper error message
+
 ## [0.1.3][]
 
 [0.1.3]: https://github.com/chaostoolkit-incubator/chaostoolkit-toxiproxy/compare/0.1.2...0.1.3

--- a/chaostoxi/toxiproxyapi.py
+++ b/chaostoxi/toxiproxyapi.py
@@ -24,8 +24,8 @@ def modify_proxy(proxy_name: str, proxy_json: Dict[str, Any],
     url = "{}/{}".format(base_url, proxy_name)
     logger.debug("Toxiproxy server API located at {}".format(url))
     response = requests.post(url, json=proxy_json)
-    if response.ok:
-        logger.debug("Unable to create proxy, response code {} with {}".format(
+    if not response.ok:
+        logger.debug("Unable to modify proxy, response code {} with {}".format(
             response.status_code, response.text))
         return None
     return response.json()


### PR DESCRIPTION
I tried modifying a proxy object with `enable_proxy` and `disable_proxy`: 

```
{
            "type": "action",
            "name": "disable-consul",
            "provider": {
              "type": "python",
              "arguments": {
                "proxy_name": "consul"
              },
              "module": "chaostoxi.proxy.actions",
              "func": "disable_proxy"
            }
          }
```

This fails with the following message (--verbose):

```
[2018-11-23 23:25:44 INFO] [experiment:280] Let's rollback...
[2018-11-23 23:25:44 INFO] [rollback:28] Rollback: reenable-consul
[2018-11-23 23:25:44 INFO] [activity:158] Action: reenable-consul
[2018-11-23 23:25:44 DEBUG] [actions:81] Modifying proxy with the following data: {'enabled': True}
[2018-11-23 23:25:44 DEBUG] [toxiproxyapi:83] Calculated toxiproxy URL is: http://host.docker.internal:8474/proxies
[2018-11-23 23:25:44 DEBUG] [toxiproxyapi:25] Toxiproxy server API located at http://host.docker.internal:8474/proxies/consul
[2018-11-23 23:25:44 DEBUG] [toxiproxyapi:29] Unable to create proxy, response code 200 with {"name":"consul","listen":"[::]:8501","upstream":"host.docker.internal:8500","enabled":true,"toxics":[]}
[2018-11-23 23:25:44 ERROR] [actions:85] Unable to modify proxy consul
[2018-11-23 23:25:44 DEBUG] [activity:225] Activity failed
    Traceback (most recent call last):
      File "/usr/local/lib/python3.5/site-packages/chaoslib/provider/python.py", line 50, in run_python_activity
        return func(**arguments)
      File "/usr/local/lib/python3.5/site-packages/chaostoxi/proxy/actions.py", line 63, in enable_proxy
        configuration=configuration)
      File "/usr/local/lib/python3.5/site-packages/chaostoxi/proxy/actions.py", line 86, in modify_proxy
        raise AssertionError
    AssertionError

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/local/lib/python3.5/site-packages/chaoslib/activity.py", line 218, in run_activity
        result = run_python_activity(activity, configuration, secrets)
      File "/usr/local/lib/python3.5/site-packages/chaoslib/provider/python.py", line 55, in run_python_activity
        sys.exc_info()[2])
      File "/usr/local/lib/python3.5/site-packages/chaoslib/provider/python.py", line 50, in run_python_activity
        return func(**arguments)
      File "/usr/local/lib/python3.5/site-packages/chaostoxi/proxy/actions.py", line 63, in enable_proxy
        configuration=configuration)
      File "/usr/local/lib/python3.5/site-packages/chaostoxi/proxy/actions.py", line 86, in modify_proxy
        raise AssertionError
    chaoslib.exceptions.ActivityFailed: AssertionError
[2018-11-23 23:25:44 ERROR] [activity:183]   => failed: AssertionError
```

Afaict from the logs, it gets a 200 response (the proxy is actually enabled/disabled afterwards, but the action fails nontheless. The code at https://github.com/chaostoolkit-incubator/chaostoolkit-toxiproxy/blob/master/chaostoxi/toxiproxyapi.py#L27-L28 does not check the response correctly IMO (compared to the other functions in the module), thus my proprosed fix.

NOTE: I haven't tested this, so please double check.