### PR TITLE
Use 'setup.py test' to run tests in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,9 @@ skipsdist = True
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
-deps = -r{toxinidir}/requirements-dev.txt
-       flake8
 
 commands =
-    python3 -m pytest tests
+    python3 setup.py test
 
 install_command = pip3 install {opts} {packages}
 


### PR DESCRIPTION
Closes https://github.com/chaostoolkit-incubator/chaostoolkit-toxiproxy/issues/8