### PR TITLE
Fix parsing of int upstream_port when checking for env variable

### DIFF
--- a/chaostoxi/proxy/actions.py
+++ b/chaostoxi/proxy/actions.py
@@ -101,7 +101,10 @@ def delete_proxy(proxy_name: str, configuration: Configuration = None):
 
 
 def value_from_environment_if_exists(key: str):
-    if key.startswith("env:"):
+    """
+    Replace key with an environment variable if it has prefix `env:`
+    """
+    if isinstance(key, str) and key.startswith("env:"):
         env_key = key[4:]
         logger.debug("Resolving from environment variable: {}".format(env_key))
         return environ[env_key]

--- a/tests/test_proxy_actions.py
+++ b/tests/test_proxy_actions.py
@@ -16,7 +16,7 @@ class TestActionMethods (unittest.TestCase):
                 "upstream": "10.28.188.118:6040"
         }
         self.assertTrue(actions.create_proxy(proxy_name="proxyone", listen_port=0, upstream_host="127.0.0.1",
-                                             upstream_port="8080", configuration=mockconfig))
+                                             upstream_port=8080, configuration=mockconfig))
         # the action has the side effect of adding the proxy port into the config with the key proxyname_PORT
         mockconfig.__setitem__.assert_called_once_with('proxyone_PORT', '6660')
         self.assertTrue(environ['proxyone_PORT'], '6660')


### PR DESCRIPTION
Closes https://github.com/chaostoolkit-incubator/chaostoolkit-toxiproxy/issues/7 (error when creating proxy)